### PR TITLE
Update tsconfig.json

### DIFF
--- a/node/basic/tsconfig.json
+++ b/node/basic/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "outDir": "build",
+    "rootDir": "src",
   },
   "include": [
     "./**/*"


### PR DESCRIPTION
I added outDir and rootDir for nodejs because nodejs does not directly run TypeScript in production like the case for bun or deno.